### PR TITLE
Rename popup classes to use consistent naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ _Supported Formats: JSON, CSV, XLSX..._
 
 #### Dependencies
 * [abap2UI5](https://github.com/abap2UI5/abap2UI5)
+* [popups](https://github.com/abap2UI5-addons/popups)
 * [abap2xlsx](https://github.com/abap2xlsx/abap2xlsx)
 
 #### Limitations & Todo

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -14,6 +14,11 @@
       "files": "/src/**/*.*"
     },
     {
+      "url": "https://github.com/abap2UI5-addons/popups",
+      "folder": "/popups",
+      "files": "/src/**/*.*"
+    },
+    {
       "url": "https://github.com/abap2xlsx/abap2xlsx",
       "folder": "/abap2xlsx",
       "files": "/src/**/*.*"

--- a/src/z2ui5_cl_tcl_app_01.clas.abap
+++ b/src/z2ui5_cl_tcl_app_01.clas.abap
@@ -48,7 +48,7 @@ CLASS Z2UI5_CL_TCL_APP_01 IMPLEMENTATION.
 
     IF client->get( )-check_on_navigated = abap_true.
       TRY.
-          DATA(lo_popup_file) = CAST z2ui5_cl_pop_file_ul( client->get_app( client->get( )-s_draft-id_prev_app ) ).
+          DATA(lo_popup_file) = CAST z2ui5_cl_popup_file_ul( client->get_app( client->get( )-s_draft-id_prev_app ) ).
           IF lo_popup_file->result( )-check_confirmed = abap_true.
             ms_app-file = lo_popup_file->result( )-value.
             client->message_toast_display( `File uploaded successfully` ).
@@ -59,7 +59,7 @@ CLASS Z2UI5_CL_TCL_APP_01 IMPLEMENTATION.
         CATCH cx_root.
       ENDTRY.
       TRY.
-          DATA(lo_popup_confirm) = CAST z2ui5_cl_pop_to_confirm( client->get_app( client->get( )-s_draft-id_prev_app ) ).
+          DATA(lo_popup_confirm) = CAST z2ui5_cl_popup_to_confirm( client->get_app( client->get( )-s_draft-id_prev_app ) ).
           IF lo_popup_confirm->result( ) = abap_true.
 
             FIELD-SYMBOLS <tab2> TYPE STANDARD TABLE.
@@ -138,13 +138,13 @@ CLASS Z2UI5_CL_TCL_APP_01 IMPLEMENTATION.
           ENDIF.
         ENDLOOP.
 
-        client->nav_app_call( z2ui5_cl_pop_table=>factory( <tab2> ) ).
+        client->nav_app_call( z2ui5_cl_popup_table=>factory( <tab2> ) ).
 
       WHEN 'DB_SAVE'.
-        client->nav_app_call( z2ui5_cl_pop_to_confirm=>factory( `Database will be deleted and new entries filled. Are you sure?` ) ).
+        client->nav_app_call( z2ui5_cl_popup_to_confirm=>factory( `Database will be deleted and new entries filled. Are you sure?` ) ).
 
       WHEN 'UPLOAD'.
-        client->nav_app_call( z2ui5_cl_pop_file_ul=>factory( ) ).
+        client->nav_app_call( z2ui5_cl_popup_file_ul=>factory( ) ).
 
       WHEN 'BUTTON_CANCEL'.
         client->message_toast_display( |cancel| ).

--- a/src/z2ui5_cl_tcl_app_03.clas.abap
+++ b/src/z2ui5_cl_tcl_app_03.clas.abap
@@ -122,10 +122,10 @@ CLASS z2ui5_cl_tcl_app_03 IMPLEMENTATION.
         UP TO 10 ROWS.
 
         DATA(lv_prev_json) = z2ui5_cl_util=>json_stringify( <tab2> ).
-        client->nav_app_call( z2ui5_cl_pop_textedit=>factory( lv_prev_json ) ).
+        client->nav_app_call( z2ui5_cl_popup_textedit=>factory( lv_prev_json ) ).
 
       WHEN 'DOWNLOAD'.
-        client->nav_app_call( z2ui5_cl_pop_file_dl=>factory( ms_app-file ) ).
+        client->nav_app_call( z2ui5_cl_popup_file_dl=>factory( ms_app-file ) ).
 
       WHEN 'BUTTON_CANCEL'.
         client->message_toast_display( |cancel| ).

--- a/src/z2ui5_cl_tcl_app_06.clas.abap
+++ b/src/z2ui5_cl_tcl_app_06.clas.abap
@@ -123,7 +123,7 @@ CLASS Z2UI5_CL_TCL_APP_06 IMPLEMENTATION.
 
     TRY.
         DATA(lo_prev) = client->get_app( client->get( )-s_draft-id_prev_app ).
-        ms_draft-table_name = CAST z2ui5_cl_pop_input_val( lo_prev )->result( )-value.
+        ms_draft-table_name = CAST z2ui5_cl_popup_input_val( lo_prev )->result( )-value.
         ms_draft-check_load_pressed = abap_true.
 
         ms_draft-t_tab = z2ui5_cl_util=>rtti_create_tab_by_name( ms_draft-table_name ).
@@ -235,7 +235,7 @@ CLASS Z2UI5_CL_TCL_APP_06 IMPLEMENTATION.
         set_view( ).
 
       WHEN `NEW`.
-        DATA(lo_app) = z2ui5_cl_pop_input_val=>factory(
+        DATA(lo_app) = z2ui5_cl_popup_input_val=>factory(
             title   = `Create a New XLSX Draft`
             text    = `Database Table:`
             val     = ms_draft-table_name ).


### PR DESCRIPTION
## Summary
This PR updates all popup class references throughout the codebase to use a consistent naming convention. The popup classes are being renamed from abbreviated names (e.g., `z2ui5_cl_pop_*`) to more explicit names (e.g., `z2ui5_cl_popup_*`).

## Key Changes
- Renamed popup class references in `z2ui5_cl_tcl_app_01.clas.abap`:
  - `z2ui5_cl_pop_file_ul` → `z2ui5_cl_popup_file_ul`
  - `z2ui5_cl_pop_to_confirm` → `z2ui5_cl_popup_to_confirm`
  - `z2ui5_cl_pop_table` → `z2ui5_cl_popup_table`

- Renamed popup class references in `z2ui5_cl_tcl_app_03.clas.abap`:
  - `z2ui5_cl_pop_textedit` → `z2ui5_cl_popup_textedit`
  - `z2ui5_cl_pop_file_dl` → `z2ui5_cl_popup_file_dl`

- Renamed popup class references in `z2ui5_cl_tcl_app_06.clas.abap`:
  - `z2ui5_cl_pop_input_val` → `z2ui5_cl_popup_input_val`

- Updated `README.md` to document the new `popups` dependency
- Updated `abaplint.jsonc` to include the popups addon dependency configuration

## Implementation Details
All CAST operations and factory method calls have been updated to use the new class names. This change improves code readability by using more explicit naming conventions while maintaining the same functionality.

https://claude.ai/code/session_01EUm2VFnKDYma7WNGyBT3qb